### PR TITLE
Apply red theme styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ring Kings - Best Boxing Gear</title>
     <meta name="description" content="Discover top boxing equipment with curated Amazon affiliate links.">
+    <meta name="theme-color" content="#8B0000">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">

--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@ body {
 }
 
 header {
-    background-color: #222;
+    background-color: #8B0000;
     color: white;
     padding: 20px;
     text-align: center;
@@ -46,19 +46,19 @@ header {
     display: inline-block;
     margin-top: 10px;
     padding: 10px 15px;
-    background-color: #007bff;
+    background-color: #cc0000;
     color: #fff;
     text-decoration: none;
     border-radius: 4px;
 }
 
 .button:hover {
-    background-color: #0056b3;
+    background-color: #990000;
 }
 
 footer {
     text-align: center;
     padding: 20px;
-    background-color: #222;
+    background-color: #8B0000;
     color: white;
 }


### PR DESCRIPTION
## Summary
- set primary theme color to dark red for a professional look
- update meta theme-color tag

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dd4ac2c04832c806386a8ac8da5a2